### PR TITLE
Fix path to kustomization in site_gen.sh

### DIFF
--- a/site_gen.sh
+++ b/site_gen.sh
@@ -17,4 +17,10 @@ else
   exit 0
 fi
 
-echo "  - "$CLUSTER_NAME >> ./sites/kustomization.yaml
+kustom="./manifests/sites/kustomization.yaml"
+# Ensure a newline exists on last line in kustomization
+last_byte=$( tail -c 1 ${kustom} | xxd -ps )
+if [ ${last_byte:-error} != "0a" ] ; then
+    echo "" >> ${kustom}
+fi
+echo "  - "$CLUSTER_NAME >> ${kustom}


### PR DESCRIPTION
The site_gen helper script had an incorrect path for the sites kustomization. This PR fixes that path and ensures kustomization has the necessary newline at the end before appending.